### PR TITLE
Support Python 3

### DIFF
--- a/bazel_to_cmake.py
+++ b/bazel_to_cmake.py
@@ -266,8 +266,13 @@ def GetDict(obj):
 
 globs = GetDict(converter)
 
-execfile("WORKSPACE", GetDict(WorkspaceFileFunctions(converter)))
-execfile("BUILD", GetDict(BuildFileFunctions(converter)))
+with open("WORKSPACE") as f:
+  code = compile(f.read(), "WORKSPACE", "exec")
+  exec(code, GetDict(WorkspaceFileFunctions(converter)))
+
+with open("BUILD") as f:
+  code = compile(f.read(), "BUILD", "exec")
+  exec(code, GetDict(BuildFileFunctions(converter)))
 
 with open(sys.argv[1], "w") as f:
   f.write(converter.convert())

--- a/bazel_to_cmake.py
+++ b/bazel_to_cmake.py
@@ -274,5 +274,6 @@ with open("BUILD") as f:
   code = compile(f.read(), "BUILD", "exec")
   exec(code, GetDict(BuildFileFunctions(converter)))
 
-with open(sys.argv[1], "w") as f:
+output_file = sys.argv[1] if len(sys.argv) > 0 else "CMakeLists.txt"
+with open(output_file, "w") as f:
   f.write(converter.convert())

--- a/bazel_to_cmake.py
+++ b/bazel_to_cmake.py
@@ -258,7 +258,7 @@ def GetDict(obj):
   ret = {}
   for k in dir(obj):
     if not k.startswith("_"):
-      ret[k] = getattr(obj, k);
+      ret[k] = getattr(obj, k)
   return ret
 
 globs = GetDict(converter)

--- a/bazel_to_cmake.py
+++ b/bazel_to_cmake.py
@@ -266,13 +266,13 @@ def GetDict(obj):
 
 globs = GetDict(converter)
 
-with open("WORKSPACE") as f:
-  code = compile(f.read(), "WORKSPACE", "exec")
-  exec(code, GetDict(WorkspaceFileFunctions(converter)))
+def exec_file(filepath, globals_=None, locals_=None):
+    with open(filepath) as f:
+        code = compile(f.read(), filepath, "exec")
+        exec(code, globals_, locals_)
 
-with open("BUILD") as f:
-  code = compile(f.read(), "BUILD", "exec")
-  exec(code, GetDict(BuildFileFunctions(converter)))
+exec_file("WORKSPACE", GetDict(WorkspaceFileFunctions(converter)))
+exec_file("BUILD", GetDict(BuildFileFunctions(converter)))
 
 output_file = sys.argv[1] if len(sys.argv) > 0 else "CMakeLists.txt"
 with open(output_file, "w") as f:

--- a/bazel_to_cmake.py
+++ b/bazel_to_cmake.py
@@ -123,6 +123,9 @@ class BuildFileFunctions(object):
   def exports_files(self, files, **kwargs):
     pass
 
+  def package(self, **kwargs):
+    pass
+
   def proto_library(self, **kwargs):
     pass
 


### PR DESCRIPTION
Hi!

I added `exec_file` function which is analog for execfile in Python 2, but working for Python 3 too.
Discussion: https://stackoverflow.com/questions/436198/what-is-an-alternative-to-execfile-in-python-3

And some little changes.