### PR TITLE
Update built-in function for Python3 support

### DIFF
--- a/bazel_to_cmake.py
+++ b/bazel_to_cmake.py
@@ -263,8 +263,12 @@ def GetDict(obj):
 
 globs = GetDict(converter)
 
-execfile("WORKSPACE", GetDict(WorkspaceFileFunctions(converter)))
-execfile("BUILD", GetDict(BuildFileFunctions(converter)))
+# execfile() not supported in Python 3; replaced by exec()
+# execfile("WORKSPACE", GetDict(WorkspaceFileFunctions(converter)))
+# execfile("BUILD", GetDict(BuildFileFunctions(converter)))
+
+exec(open("WORKSPACE", "rb").read(), GetDict(WorkspaceFileFunctions(converter)))
+exec(open("BUILD", "rb").read(), GetDict(BuildFileFunctions(converter)))
 
 with open(sys.argv[1], "w") as f:
   f.write(converter.convert())


### PR DESCRIPTION
Original code has Python 2 had the built-in function execfile, which was removed in Python 3.
This branch contains an update for this function by replace execfile with exec supported in Python 3.